### PR TITLE
fix: use build info for go-install version

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -52,6 +52,8 @@ Go 1.26 or newer is required.
 go install github.com/harumiWeb/eitango/cmd/eitango@latest
 ```
 
+Builds installed with `go install` also report the embedded module version in `eitango version`.
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Go 1.26 以降を前提にしています。
 go install github.com/harumiWeb/eitango/cmd/eitango@latest
 ```
 
+`go install` で導入した build でも、`eitango version` は埋め込まれた module version を表示します。
+
 ## クイックスタート
 
 ```bash

--- a/cmd/eitango/main.go
+++ b/cmd/eitango/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -26,6 +27,8 @@ var (
 	commit  = "unknown"
 	date    = "unknown"
 
+	readBuildInfo = debug.ReadBuildInfo
+
 	newUpdateService = func(dataDir string) updatecheck.Service {
 		return updatecheck.New(updatecheck.DefaultStatePath(dataDir))
 	}
@@ -46,12 +49,13 @@ func main() {
 }
 
 func newRootCommand() *cobra.Command {
+	currentVersion := resolvedVersion()
 	cmd := &cobra.Command{
 		Use:           "eitango",
 		Short:         i18n.T(i18n.CLIRootShort),
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		Version:       buildVersionText(),
+		Version:       formatBuildVersion("eitango", currentVersion, commit, date),
 		RunE:          runDashboard,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return maybePrintLicense(cmd)
@@ -94,6 +98,7 @@ func newReviewCommand() *cobra.Command {
 
 func runDashboard(cmd *cobra.Command, args []string) error {
 	ctx := commandContext(cmd)
+	currentVersion := resolvedVersion()
 	st, settings, err := openStore(ctx)
 	if err != nil {
 		return err
@@ -110,7 +115,7 @@ func runDashboard(cmd *cobra.Command, args []string) error {
 		Plan:           mustSessionOptions(settings, nil, nil),
 		Settings:       settings,
 		ConfigPath:     paths.ConfigPath,
-		CurrentVersion: version,
+		CurrentVersion: currentVersion,
 		UpdateService:  newUpdateService(paths.DataDir),
 	}))
 	_, err = program.Run()
@@ -119,6 +124,7 @@ func runDashboard(cmd *cobra.Command, args []string) error {
 
 func runLearn(cmd *cobra.Command, args []string) error {
 	ctx := commandContext(cmd)
+	currentVersion := resolvedVersion()
 	st, settings, err := openStore(ctx)
 	if err != nil {
 		return err
@@ -148,7 +154,7 @@ func runLearn(cmd *cobra.Command, args []string) error {
 		Plan:           options,
 		Settings:       settings,
 		ConfigPath:     paths.ConfigPath,
-		CurrentVersion: version,
+		CurrentVersion: currentVersion,
 		UpdateService:  newUpdateService(paths.DataDir),
 	}))
 	_, err = program.Run()
@@ -157,6 +163,7 @@ func runLearn(cmd *cobra.Command, args []string) error {
 
 func runReview(cmd *cobra.Command, args []string) error {
 	ctx := commandContext(cmd)
+	currentVersion := resolvedVersion()
 	st, settings, err := openStore(ctx)
 	if err != nil {
 		return err
@@ -190,7 +197,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 		Plan:           options,
 		Settings:       settings,
 		ConfigPath:     paths.ConfigPath,
-		CurrentVersion: version,
+		CurrentVersion: currentVersion,
 		UpdateService:  newUpdateService(paths.DataDir),
 		Startup: &app.StartupRequest{
 			Mode:          store.ModeReview,
@@ -225,10 +232,11 @@ func newStatsCommand() *cobra.Command {
 }
 
 func runVersion(cmd *cobra.Command, args []string) error {
+	currentVersion := resolvedVersion()
 	result := updatecheck.Result{}
 	if paths, err := config.Resolve(); err == nil {
 		if service := newUpdateService(paths.DataDir); service != nil {
-			result, _ = service.CheckNow(commandContext(cmd), version)
+			result, _ = service.CheckNow(commandContext(cmd), currentVersion)
 		}
 	}
 	_, err := fmt.Fprint(cmd.OutOrStdout(), formatVersionReport(result))
@@ -462,7 +470,7 @@ func maybePrintLicense(cmd *cobra.Command) error {
 }
 
 func buildVersionText() string {
-	return formatBuildVersion("eitango", version, commit, date)
+	return formatBuildVersion("eitango", resolvedVersion(), commit, date)
 }
 
 func formatVersionReport(result updatecheck.Result) string {
@@ -485,6 +493,32 @@ func formatVersionReport(result updatecheck.Result) string {
 		}
 	}
 	return b.String()
+}
+
+func resolvedVersion() string {
+	currentVersion := strings.TrimSpace(version)
+	if currentVersion != "" && currentVersion != "dev" {
+		return currentVersion
+	}
+	if buildVersion := moduleBuildVersion(); buildVersion != "" {
+		return buildVersion
+	}
+	return defaultBuildValue(currentVersion, "dev")
+}
+
+func moduleBuildVersion() string {
+	info, ok := readBuildInfo()
+	if !ok || info == nil {
+		return ""
+	}
+
+	buildVersion := strings.TrimSpace(info.Main.Version)
+	switch buildVersion {
+	case "", "(devel)":
+		return ""
+	default:
+		return buildVersion
+	}
 }
 
 func formatBuildVersion(name, version, commit, date string) string {

--- a/cmd/eitango/main_test.go
+++ b/cmd/eitango/main_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"testing"
 	"time"
@@ -132,6 +133,19 @@ func TestNewRootCommandIncludesReviewCommandAndFlags(t *testing.T) {
 }
 
 func TestNewRootCommandVersionFlag(t *testing.T) {
+	originalVersion := version
+	originalReadBuildInfo := readBuildInfo
+	version = "dev"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{Version: "v1.2.3"},
+		}, true
+	}
+	t.Cleanup(func() {
+		version = originalVersion
+		readBuildInfo = originalReadBuildInfo
+	})
+
 	var out bytes.Buffer
 	cmd := newRootCommand()
 	cmd.SetOut(&out)
@@ -143,8 +157,8 @@ func TestNewRootCommandVersionFlag(t *testing.T) {
 	}
 
 	output := out.String()
-	if !strings.Contains(output, "eitango ") {
-		t.Fatalf("version output = %q, want app name", output)
+	if !strings.Contains(output, "eitango v1.2.3") {
+		t.Fatalf("version output = %q, want resolved module version", output)
 	}
 	if !strings.Contains(output, "commit: ") {
 		t.Fatalf("version output = %q, want commit line", output)
@@ -212,6 +226,42 @@ func TestFormatBuildVersion(t *testing.T) {
 	}
 }
 
+func TestResolvedVersionUsesBuildInfoWhenLdflagsUnset(t *testing.T) {
+	originalVersion := version
+	originalReadBuildInfo := readBuildInfo
+	version = "dev"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{Version: "v1.2.3"},
+		}, true
+	}
+	t.Cleanup(func() {
+		version = originalVersion
+		readBuildInfo = originalReadBuildInfo
+	})
+
+	if got := resolvedVersion(); got != "v1.2.3" {
+		t.Fatalf("resolvedVersion() = %q, want v1.2.3", got)
+	}
+}
+
+func TestResolvedVersionFallsBackToDevWithoutBuildInfo(t *testing.T) {
+	originalVersion := version
+	originalReadBuildInfo := readBuildInfo
+	version = "dev"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return nil, false
+	}
+	t.Cleanup(func() {
+		version = originalVersion
+		readBuildInfo = originalReadBuildInfo
+	})
+
+	if got := resolvedVersion(); got != "dev" {
+		t.Fatalf("resolvedVersion() = %q, want dev", got)
+	}
+}
+
 func TestFormatVersionReportIncludesLatestRelease(t *testing.T) {
 	t.Parallel()
 
@@ -236,6 +286,19 @@ func TestFormatVersionReportIncludesLatestRelease(t *testing.T) {
 }
 
 func TestVersionCommandShowsLatestRelease(t *testing.T) {
+	originalVersion := version
+	originalReadBuildInfo := readBuildInfo
+	version = "dev"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{Version: "v1.2.3"},
+		}, true
+	}
+	t.Cleanup(func() {
+		version = originalVersion
+		readBuildInfo = originalReadBuildInfo
+	})
+
 	service := &mainStubUpdateService{
 		checkNowResult: updatecheck.Result{
 			Latest: updatecheck.ReleaseInfo{
@@ -269,8 +332,12 @@ func TestVersionCommandShowsLatestRelease(t *testing.T) {
 	if service.checkNowCalls != 1 {
 		t.Fatalf("checkNowCalls = %d, want 1", service.checkNowCalls)
 	}
+	if service.checkNowVersion != "v1.2.3" {
+		t.Fatalf("checkNowVersion = %q, want v1.2.3", service.checkNowVersion)
+	}
 	output := out.String()
 	for _, want := range []string{
+		"eitango v1.2.3",
 		"latest: v1.2.4",
 		"release: https://example.com/eitango/v1.2.4",
 		"status: update available",
@@ -635,16 +702,18 @@ func mustMetaValue(t *testing.T, dbPath, key string) string {
 }
 
 type mainStubUpdateService struct {
-	checkNowResult updatecheck.Result
-	checkNowErr    error
-	checkNowCalls  int
+	checkNowResult  updatecheck.Result
+	checkNowErr     error
+	checkNowCalls   int
+	checkNowVersion string
 }
 
 func (s *mainStubUpdateService) Check(context.Context, string) (updatecheck.Result, error) {
 	return updatecheck.Result{}, nil
 }
 
-func (s *mainStubUpdateService) CheckNow(context.Context, string) (updatecheck.Result, error) {
+func (s *mainStubUpdateService) CheckNow(_ context.Context, currentVersion string) (updatecheck.Result, error) {
 	s.checkNowCalls++
+	s.checkNowVersion = currentVersion
 	return s.checkNowResult, s.checkNowErr
 }

--- a/tasks/feature_spec.md
+++ b/tasks/feature_spec.md
@@ -28,3 +28,37 @@
 - `docs/adr/` の 3 本が `Status`, `Background`, `Decision`, `Consequences`, `Rationale`, `Supersedes`, `Superseded by` を持つ。
 - `rg -n "docs/design\.md|design\.md"` で削除済み設計書への壊れた参照が残らない。
 - `go test ./...` が通る。
+
+---
+
+# 2026-03-30 issue #3: go install 時の version 表示仕様
+
+## Goal
+
+- `go install github.com/harumiWeb/eitango/cmd/eitango@latest` で導入したバイナリでも `eitango version` と update check 比較対象が `dev` ではなく実バージョンを使う。
+
+## Scope
+
+- `cmd/eitango/main.go` の build version 解決ロジック
+- 版情報を使う CLI 表示と update check 呼び出し
+- 回帰テスト
+- README の install / update 説明の最小補足
+
+## Non-Goals
+
+- release build の `ldflags` 方針変更
+- local checkout 上の `go run ./cmd/eitango` や `go install ./cmd/eitango` を release version 扱いすること
+- `commit` / `date` の解決方式変更
+
+## Required Behavior
+
+- `main.version` が `ldflags` で上書き済みなら、その値を最優先で使う。
+- `main.version` が `dev` の場合だけ `runtime/debug.ReadBuildInfo()` を参照し、`Main.Version` が semver や pseudo-version のような実値ならそれを使う。
+- `Main.Version` が空文字または `"(devel)"` の場合は `dev` を維持する。
+- `--version`、`version` サブコマンド、update check への `CurrentVersion` は同じ解決済み version を使う。
+
+## Acceptance
+
+- `go install github.com/harumiWeb/eitango/cmd/eitango@latest` 由来の build info を模したテストで `dev` ではなく `vX.Y.Z` が表示される。
+- build info がないケースでは従来どおり `dev` が表示される。
+- `go test ./...` が通る。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3,6 +3,15 @@
 このファイルは、初回 OSS リリースに向けた active backlog だけを管理する。
 完了済みの長い履歴、旧 30k ロードマップ、設計との差分棚卸しはここには残さない。
 
+## 2026-03-30 issue #3: go install version 表示
+
+- [x] `dev` のときだけ build info の `Main.Version` を使う解決ロジックを追加する
+- [x] `--version` / `version` / update check の参照 version を統一する
+- [x] `go install @latest` 相当の回帰テストを追加する
+- [x] README の install / update 説明を最小限補足する
+- [x] `go test ./...` を通す
+- [ ] 公開 release 更新後に `go install github.com/harumiWeb/eitango/cmd/eitango@latest` 実機で `dev` 解消を再確認する
+
 ## 2026-03-29 ドキュメント再編
 
 - [x] 旧設計書のうち current code に効いている判断だけを抽出する


### PR DESCRIPTION
## Summary
- resolve the CLI version from Go build info when `ldflags` leave `main.version` as `dev`
- use the resolved version consistently for `--version`, the `version` subcommand, and update checks
- add regression coverage for `go install @latest` builds and document the behavior in both READMEs

## Testing
- `go test ./...`
- pre-commit hooks: `goimports`, `lint`

Closes #3