### PR TITLE
Add winget release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,10 @@ builds:
         goarch: arm64
 
 archives:
-  - formats: [tar.gz]
+  - id: unix-archives
+    ids:
+      - eitango
+    formats: [tar.gz]
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_
       {{- .Os }}_
@@ -41,7 +44,61 @@ archives:
       - third_party/licenses/**
     format_overrides:
       - goos: windows
-        formats: [zip]
+        formats: [none]
+  - id: windows-archive
+    ids:
+      - eitango
+    formats: [zip]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - LICENSE
+      - README.md
+      - README.en.md
+      - THIRD_PARTY_NOTICES.md
+      - third_party/licenses/**
+    format_overrides:
+      - goos: darwin
+        formats: [none]
+      - goos: linux
+        formats: [none]
+
+winget:
+  - name: eitango
+    publisher: HarumiWeb
+    package_identifier: HarumiWeb.Eitango
+    package_name: eitango
+    short_description: Terminal-based English vocabulary learning CLI.
+    description: Interactive English vocabulary learning CLI built with Go.
+    license: Apache-2.0
+    homepage: https://github.com/harumiWeb/eitango
+    publisher_url: https://github.com/harumiWeb
+    publisher_support_url: https://github.com/harumiWeb/eitango/issues
+    license_url: https://github.com/harumiWeb/eitango/blob/{{ .Tag }}/LICENSE
+    tags:
+      - go
+      - cli
+      - english
+      - learning
+      - vocabulary
+    ids:
+      - windows-archive
+    repository:
+      owner: harumiWeb
+      name: winget-pkgs
+      branch: eitango-{{ .Version }}
+      token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
+    commit_msg_template: "{{ .PackageIdentifier }}: {{ .Tag }}"
+    skip_upload: "{{ if .Prerelease }}true{{ else }}false{{ end }}"
 
 checksum:
   name_template: checksums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-04-04
+
+### Added
+
+- Windows 向けの `winget install HarumiWeb.Eitango` 導線を追加しました。
+
+### Changed
+
+- release フローから `harumiWeb/winget-pkgs` fork へ manifest を生成し、`microsoft/winget-pkgs` へ PR を作成できるようにしました。
+- GoReleaser の archive 構成を整理し、winget では GitHub Releases に公開した Windows zip のみを参照するようにしました。
+- README / README.en / 配布ポリシー ADR を Windows の winget 配布方針に合わせて更新しました。
+
 ## [0.5.0] - 2026-04-03
 
 ### Added
@@ -111,7 +123,8 @@
 - 通知不要時に古い update tag が画面に残る問題を修正しました。
 - `dev` など非 semver の build でも update availability を正しく判定するようにしました。
 
-[Unreleased]: https://github.com/harumiWeb/eitango/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/harumiWeb/eitango/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/harumiWeb/eitango/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/harumiWeb/eitango/compare/v0.4.2...v0.5.0
 [0.4.2]: https://github.com/harumiWeb/eitango/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/harumiWeb/eitango/compare/v0.4.0...v0.4.1

--- a/README.en.md
+++ b/README.en.md
@@ -57,7 +57,23 @@ The embedded vocabulary currently contains about **5200** words, and external di
 
 ## Installation
 
-### 1. Use `curl | sh` on macOS / Linux
+### 1. Use winget on Windows
+
+On Windows, you can install `eitango` from winget. The manifest points to the Windows zip published in GitHub Releases.
+
+```powershell
+winget install HarumiWeb.Eitango
+```
+
+To upgrade:
+
+```powershell
+winget upgrade HarumiWeb.Eitango
+```
+
+If you do not want to use winget, you can still use the GitHub Releases zip described below.
+
+### 2. Use `curl | sh` on macOS / Linux
 
 `install.sh` calls the GitHub Releases API (`/releases/latest`) when `--version` is omitted to resolve the latest version, then downloads the matching GitHub Release archive and `checksums.txt`. It installs into `~/.eitango/` only after the SHA256 check passes, and it never edits shell rc files automatically.
 
@@ -102,15 +118,15 @@ To also delete the data directory, add `--purge-data`. If you use `EITANGO_DATA_
 curl -fsSL https://raw.githubusercontent.com/harumiWeb/eitango/main/install.sh | sh -s -- --uninstall --purge-data
 ```
 
-Required tools are `sh`, `curl`, `tar`, `mktemp`, and one of `sha256sum`, `shasum`, or `openssl`. Windows is out of scope for this installer, so use the release zip there.
+Required tools are `sh`, `curl`, `tar`, `mktemp`, and one of `sha256sum`, `shasum`, or `openssl`. Windows is out of scope for this installer, so use winget or the release zip there.
 
-### 2. Use GitHub Releases
+### 3. Use GitHub Releases
 
 Published archives include the executable plus `LICENSE`, `THIRD_PARTY_NOTICES.md`, and `third_party/licenses/`. Extract the artifact for your OS and run `eitango`.
 
 ※ You need to manually add it to your `PATH`.
 
-### 3. Install with Go
+### 4. Install with Go
 
 Go 1.26 or newer is required.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,23 @@ SRS での復習に加えて、選択式の `choice` と入力式の `write` の
 
 ## インストール
 
-### 1. macOS / Linux は `curl | sh` を使う
+### 1. Windows は winget を使う
+
+Windows では winget から install できます。manifest は GitHub Releases に公開した Windows zip を参照します。
+
+```powershell
+winget install HarumiWeb.Eitango
+```
+
+更新は次です。
+
+```powershell
+winget upgrade HarumiWeb.Eitango
+```
+
+winget を使わない場合は後述の GitHub Releases の zip からも利用できます。
+
+### 2. macOS / Linux は `curl | sh` を使う
 
 `install.sh` は `--version` を省略した場合に GitHub Releases API (`/releases/latest`) へアクセスして最新 version を解決し、そのうえで対応する archive と `checksums.txt` を取得します。SHA256 検証が通ったときだけ `~/.eitango/` へ展開し、shell rc は自動変更しません。
 
@@ -102,15 +118,15 @@ curl -fsSL https://raw.githubusercontent.com/harumiWeb/eitango/main/install.sh |
 curl -fsSL https://raw.githubusercontent.com/harumiWeb/eitango/main/install.sh | sh -s -- --uninstall --purge-data
 ```
 
-必要ツールは `sh`, `curl`, `tar`, `mktemp` と、`sha256sum` / `shasum` / `openssl` のいずれか 1 つです。Windows は今回の installer 対象外なので、release zip を使ってください。
+必要ツールは `sh`, `curl`, `tar`, `mktemp` と、`sha256sum` / `shasum` / `openssl` のいずれか 1 つです。Windows は今回の installer 対象外なので、winget か release zip を使ってください。
 
-### 2. GitHub Releases から使う
+### 3. GitHub Releases から使う
 
 公開アーカイブにはバイナリに加えて `LICENSE`、`THIRD_PARTY_NOTICES.md`、`third_party/licenses/` が同梱されます。自分のOS向けの成果物を展開して `eitango` を実行してください。
 
 ※ `PATH`への追加は手動で行う必要があります。
 
-### 3. Go からインストールする
+### 4. Go からインストールする
 
 Go 1.26 以降を前提にしています。
 

--- a/docs/adr/0003-release-and-update-policy.md
+++ b/docs/adr/0003-release-and-update-policy.md
@@ -11,9 +11,11 @@
 ## Decision
 
 - 正規の配布チャネルは GitHub Releases とし、GoReleaser で darwin / linux / windows 向け archive を生成する。
+- Windows 向けには winget community repository も配布導線として提供するが、参照先 artifact は GitHub Releases に置いた Windows zip のみとし、release の正本は引き続き GitHub Releases に固定する。
 - release artifact には実行バイナリに加えて `LICENSE`, `README.md`, `README.en.md`, `THIRD_PARTY_NOTICES.md`, `third_party/licenses/**` を同梱する。
 - macOS / linux では `install.sh` を bootstrap 導線として許可するが、installer 自体は GitHub Releases の archive と `checksums.txt` を取得する薄い wrapper に留める。
 - `install.sh` は `checksums.txt` で SHA256 を必須検証し、法務ファイルを `~/.eitango/share/` へ保持する。
+- winget manifest は GoReleaser で release 時に生成し、`harumiWeb/winget-pkgs` fork へ push したうえで `microsoft/winget-pkgs` へ cross-repository PR を作成する。push/PR 用 token は release 用 `GITHUB_TOKEN` と分離し、`WINGET_GITHUB_TOKEN` を使う。
 - 更新は自動適用しない。新しい版の取得は release archive の再取得か `go install ...@latest` の再実行で行う。
 - update check は GitHub Releases の latest を参照する補助機能とし、学習フローを止めない best-effort 動作に限定する。
 - update check の state は data dir の `update-check.json` に保存し、ホーム画面の通知は起動ごとに latest release を非同期で再検証する。HTTP timeout は 1.5 秒とし、保存 state は request failure 時の fallback に使う。
@@ -25,12 +27,14 @@
 ## Consequences
 
 - release artifact の再配布条件と notice の同梱要件を、ビルド設定と文書で一貫して維持できる。
+- Windows 利用者には `winget install HarumiWeb.Eitango` の導線を追加できるが、artifact hosting と checksum の正本は増やさずに済む。
 - `curl | sh` の最短導線を追加しても、配布物の単一ソースは GitHub Releases のまま保てる。
 - SHA256 検証で download 途中の破損や取り違えは防ぎやすくなるが、署名付き provenance ではないため `install.sh` 本体の信頼境界は依然として HTTPS / GitHub 側にある。
 - 自動更新を持たないため、更新失敗が学習データを壊す経路を増やさずに済む。
 - update check は起動ごとに 1 回の best-effort request を行うが、最新 release 反映の遅延は大きく減り、更新作業は引き続き手動のまま保てる。
 - 保存済み state があるため、GitHub API が失敗しても直前の latest 情報を fallback として使える。
-- GitHub Releases が update metadata の単一ソースになるため、別チャネルを増やす場合は新しい判断が必要になる。
+- fork 側 PAT の期限切れや権限不足があると winget PR だけ失敗しうるため、release 失敗時は token 権限と fork 状態を先に確認する運用が必要になる。
+- GitHub Releases が update metadata と Windows zip の単一ソースになるため、別チャネルを増やす場合は新しい判断が必要になる。
 
 ## Rationale
 
@@ -42,6 +46,7 @@
   - `internal/updatecheck/checker.go`
   - `cmd/eitango/main.go`
   - `.goreleaser.yaml`
+  - `.github/workflows/release.yml`
   - `install.sh`
 - Related specs:
   - なし。コード、README、CHANGELOG、tests を正本とする。

--- a/tasks/feature_spec.md
+++ b/tasks/feature_spec.md
@@ -1,3 +1,43 @@
+# 2026-04-04 winget 配布追加
+
+## Goal
+
+- GitHub Releases の Windows zip を使って winget community repository へ manifest を提出できるようにする。
+- release 実行時に `harumiWeb/winget-pkgs` fork へ push し、`microsoft/winget-pkgs` への PR を自動生成する。
+
+## Scope
+
+- `.goreleaser.yaml` の archive / winget publish 設定
+- `.github/workflows/release.yml` の secret 注入
+- README / README.en / ADR の Windows 導線更新
+
+## Non-Goals
+
+- Windows installer の新規実装
+- GitHub Releases の asset naming 変更
+- `install.sh` の Windows 対応
+- update check の通知仕様変更
+
+## Required Behavior
+
+- darwin / linux の release archive は引き続き `tar.gz` を使い、`install.sh` が前提とする asset naming を変えない。
+- Windows 向けには winget 用の zip archive を 1 系統だけ生成し、winget manifest はその zip だけを参照する。
+- `winget.package_identifier` は `HarumiWeb.Eitango` に固定する。
+- `winget.license` はリポジトリ実態に合わせて `Apache-2.0` を使う。
+- winget publish 用の token は `repository.token: "{{ .Env.WINGET_GITHUB_TOKEN }}"` として `GITHUB_TOKEN` から分離する。
+- release workflow は `WINGET_GITHUB_TOKEN` を GoReleaser step へ渡す。
+- README / README.en は Windows の primary install 導線として `winget install HarumiWeb.Eitango` を案内する。
+
+## Acceptance
+
+- `goreleaser check` が通る。
+- `goreleaser release --snapshot --clean --skip=publish` が通る。
+- snapshot の `dist/winget` に `HarumiWeb.Eitango` の manifest 群が生成される。
+- snapshot の installer manifest が GitHub Releases の Windows zip を参照する。
+- darwin / linux の `tar.gz` naming は従来どおり維持される。
+
+---
+
 # 2026-04-01 PR #12: Codacy follow-up
 
 ## Goal

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3,6 +3,14 @@
 このファイルは、初回 OSS リリースに向けた active backlog だけを管理する。
 完了済みの長い履歴、旧 30k ロードマップ、設計との差分棚卸しはここには残さない。
 
+## 2026-04-04 winget 配布追加
+
+- [x] `.goreleaser.yaml` を dual-archive 化し、Windows zip 専用 `windows-archive` を追加する
+- [x] `winget` publish 設定を追加し、`HarumiWeb.Eitango` と `WINGET_GITHUB_TOKEN` を使う
+- [x] `.github/workflows/release.yml` で GoReleaser step へ `WINGET_GITHUB_TOKEN` を渡す
+- [x] README / README.en / ADR に Windows の winget 導線を反映する
+- [ ] 実タグ release で fork `harumiWeb/winget-pkgs` への push と upstream PR 作成を確認する
+
 ## 2026-04-01 PR #12: Codacy follow-up
 
 - [x] `doctor.go` の `PRAGMA table_info(...)` を string formatting ではなく許可テーブルの定数 query に置き換える


### PR DESCRIPTION
## Summary
- add a dedicated Windows zip archive and GoReleaser winget publishing config for HarumiWeb.Eitango
- pass WINGET_GITHUB_TOKEN through the release workflow and document the new Windows install path
- add a v0.5.1 changelog entry for the winget release work

## Testing
- goreleaser check
- goreleaser release --snapshot --clean --skip=publish
- go test ./...
- pre-commit hooks: goimports, lint, test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harumiweb/eitango/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
