### PR TITLE
Switch winget publishing to manual PR workflow

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -92,7 +92,7 @@ winget:
       branch: eitango-{{ .Version }}
       token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
       pull_request:
-        enabled: true
+        enabled: false
         base:
           owner: microsoft
           name: winget-pkgs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-04-04
+
+### Changed
+
+- winget manifest の公開フローは `harumiWeb/winget-pkgs` fork への push までを自動化し、`microsoft/winget-pkgs` への PR は手動作成に切り替えました。
+
+### Fixed
+
+- fine-grained PAT で upstream への cross-repository PR 作成が 403 になり、release workflow 全体が失敗する問題を回避しました。
+
 ## [0.5.1] - 2026-04-04
 
 ### Added

--- a/docs/adr/0003-release-and-update-policy.md
+++ b/docs/adr/0003-release-and-update-policy.md
@@ -15,7 +15,7 @@
 - release artifact には実行バイナリに加えて `LICENSE`, `README.md`, `README.en.md`, `THIRD_PARTY_NOTICES.md`, `third_party/licenses/**` を同梱する。
 - macOS / linux では `install.sh` を bootstrap 導線として許可するが、installer 自体は GitHub Releases の archive と `checksums.txt` を取得する薄い wrapper に留める。
 - `install.sh` は `checksums.txt` で SHA256 を必須検証し、法務ファイルを `~/.eitango/share/` へ保持する。
-- winget manifest は GoReleaser で release 時に生成し、`harumiWeb/winget-pkgs` fork へ push したうえで `microsoft/winget-pkgs` へ cross-repository PR を作成する。push/PR 用 token は release 用 `GITHUB_TOKEN` と分離し、`WINGET_GITHUB_TOKEN` を使う。
+- winget manifest は GoReleaser で release 時に生成し、`harumiWeb/winget-pkgs` fork へ push する。`microsoft/winget-pkgs` への PR は手動で作成し、fork への push 用 token は release 用 `GITHUB_TOKEN` と分離した `WINGET_GITHUB_TOKEN` を使う。
 - 更新は自動適用しない。新しい版の取得は release archive の再取得か `go install ...@latest` の再実行で行う。
 - update check は GitHub Releases の latest を参照する補助機能とし、学習フローを止めない best-effort 動作に限定する。
 - update check の state は data dir の `update-check.json` に保存し、ホーム画面の通知は起動ごとに latest release を非同期で再検証する。HTTP timeout は 1.5 秒とし、保存 state は request failure 時の fallback に使う。
@@ -33,7 +33,7 @@
 - 自動更新を持たないため、更新失敗が学習データを壊す経路を増やさずに済む。
 - update check は起動ごとに 1 回の best-effort request を行うが、最新 release 反映の遅延は大きく減り、更新作業は引き続き手動のまま保てる。
 - 保存済み state があるため、GitHub API が失敗しても直前の latest 情報を fallback として使える。
-- fork 側 PAT の期限切れや権限不足があると winget PR だけ失敗しうるため、release 失敗時は token 権限と fork 状態を先に確認する運用が必要になる。
+- fork 側 PAT の期限切れや権限不足があると winget manifest push が失敗しうるため、release 失敗時は token 権限と fork 状態を先に確認する運用が必要になる。upstream PR は手動運用なので、release 後に compare URL から提出する手順を別途維持する必要がある。
 - GitHub Releases が update metadata と Windows zip の単一ソースになるため、別チャネルを増やす場合は新しい判断が必要になる。
 
 ## Rationale

--- a/tasks/feature_spec.md
+++ b/tasks/feature_spec.md
@@ -3,7 +3,7 @@
 ## Goal
 
 - GitHub Releases の Windows zip を使って winget community repository へ manifest を提出できるようにする。
-- release 実行時に `harumiWeb/winget-pkgs` fork へ push し、`microsoft/winget-pkgs` への PR を自動生成する。
+- release 実行時に `harumiWeb/winget-pkgs` fork へ manifest を push し、`microsoft/winget-pkgs` への PR は手動で作成する。
 
 ## Scope
 
@@ -26,6 +26,7 @@
 - `winget.license` はリポジトリ実態に合わせて `Apache-2.0` を使う。
 - winget publish 用の token は `repository.token: "{{ .Env.WINGET_GITHUB_TOKEN }}"` として `GITHUB_TOKEN` から分離する。
 - release workflow は `WINGET_GITHUB_TOKEN` を GoReleaser step へ渡す。
+- GoReleaser は fork への push までを自動化し、upstream への cross-repository PR 作成は行わない。
 - README / README.en は Windows の primary install 導線として `winget install HarumiWeb.Eitango` を案内する。
 
 ## Acceptance

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -25,3 +25,4 @@
 - 外部コマンドの availability probe は本実行と別経路でも放置しない。`LookPath` で解決した実行パスをそのまま probe/run に渡し、startup 判定の subprocess には短い timeout を付けて hang で UI 初期化を止めない。
 - 非同期エラーを UI 用 message へ潰すときも root cause を落とさない。`audioErrMsg` のような軽量 message でも trigger source と元 error を保持し、status は短く保ったまま診断と回帰テストに使える形で残す。
 - 外部コマンド実行を security lint が見ている箇所は、validated な入力でも `exec.CommandContext(name, ...)` の形を避ける。`LookPath` は存在確認と allowlist 判定に使い、実行は静的 literal のコマンドに正規化して Semgrep/Codacy と実装意図を一致させる。
+- `winget-pkgs` のような fork 経由の upstream PR を自動化する前に、PAT の owner 境界を確認する。fine-grained PAT は選択した owner 配下の repo にしか権限を持てないので、fork への push はできても別 owner への cross-repository PR 作成は失敗しうる。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -9,7 +9,8 @@
 - [x] `winget` publish 設定を追加し、`HarumiWeb.Eitango` と `WINGET_GITHUB_TOKEN` を使う
 - [x] `.github/workflows/release.yml` で GoReleaser step へ `WINGET_GITHUB_TOKEN` を渡す
 - [x] README / README.en / ADR に Windows の winget 導線を反映する
-- [ ] 実タグ release で fork `harumiWeb/winget-pkgs` への push と upstream PR 作成を確認する
+- [x] 実タグ release で fork `harumiWeb/winget-pkgs` への push まで確認した
+- [ ] `microsoft/winget-pkgs` への PR を手動で作成し、運用手順を確認する
 
 ## 2026-04-01 PR #12: Codacy follow-up
 


### PR DESCRIPTION
## Summary
- stop GoReleaser after pushing winget manifests to the harumiWeb/winget-pkgs fork
- switch upstream microsoft/winget-pkgs PR creation to a manual step and update ADR/task notes
- add a v0.5.2 changelog entry for the release workflow fix

## Why
The v0.5.1 release succeeded through GitHub Releases and fork push, but failed when GoReleaser tried to open a cross-repository PR against microsoft/winget-pkgs with a fine-grained PAT. This change keeps the automated part that works and removes the failing step from the release workflow.

## Verification
- goreleaser check
- goreleaser release --snapshot --clean --skip=publish
- pre-commit hooks during git commit: goimports, lint, test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harumiweb/eitango/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated winget manifest release workflow to automate pushing to fork while requiring manual pull request creation to the upstream repository.

* **Fixed**
  * Mitigated release workflow failure in cross-repository pull request creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->