### PR TITLE
feat: add flake.nix for Nix-based installation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
               "-w"
               "-X main.version=${self.shortRev or self.dirtyShortRev or "dev"}"
               "-X main.commit=${self.rev or "dirty"}"
-              "-X main.date=1970-01-01T00:00:00Z"
+              "-X main.date=${self.lastModifiedDate or "1970-01-01T00:00:00Z"}"
             ];
 
             meta = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "eitango - English vocabulary learning CLI";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages = {
+          eitango = pkgs.buildGoModule {
+            pname = "eitango";
+            version = self.shortRev or self.dirtyShortRev or "dev";
+
+            src = self;
+
+            vendorHash = "sha256-fVqXrhz2wMWvWiPL8X/M0Oqz6LIRSLocKNZmEVhQLtY=";
+
+            subPackages = [ "cmd/eitango" ];
+
+            env.CGO_ENABLED = 0;
+
+            ldflags = [
+              "-s"
+              "-w"
+              "-X main.version=${self.shortRev or self.dirtyShortRev or "dev"}"
+              "-X main.commit=${self.rev or "dirty"}"
+              "-X main.date=1970-01-01T00:00:00Z"
+            ];
+
+            meta = {
+              description = "English vocabulary learning CLI with spaced repetition";
+              homepage = "https://github.com/harumiWeb/eitango";
+              mainProgram = "eitango";
+            };
+          };
+          default = self.packages.${system}.eitango;
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            go
+            gopls
+            golangci-lint
+          ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             meta = {
               description = "English vocabulary learning CLI with spaced repetition";
               homepage = "https://github.com/harumiWeb/eitango";
+              license = pkgs.lib.licenses.asl20;
               mainProgram = "eitango";
             };
           };


### PR DESCRIPTION
Hi! Thank you for maintaining eitango 🙏

This PR adds a `flake.nix` so that eitango can be installed and run via the Nix package manager.

## Summary

- Add `flake.nix` with `buildGoModule` package definition for eitango
- Enable installation via `nix profile install github:harumiWeb/eitango` or one-off execution via `nix run github:harumiWeb/eitango`
- Include a `devShell` with Go, gopls, and golangci-lint for contributors

## Usage

```bash
# Install
nix profile install github:harumiWeb/eitango

# Run without installing
nix run github:harumiWeb/eitango

# Enter dev environment
nix develop github:harumiWeb/eitango
```

## Test plan

- [x] `nix build .#eitango` succeeds
- [x] `./result/bin/eitango version` outputs correct version info
- [x] `nix flake check` passes

Please let me know if there's anything you'd like me to adjust. Happy to iterate on this!

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/harumiweb/eitango/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Nix flake configuration to improve build and distribution across multiple systems, including enhanced development environment setup with Go tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->